### PR TITLE
記事本文の画像、フッターのSP表示崩れ修正

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -42,6 +42,11 @@
     list-style: none;
     padding: 0;
   }
+  @media screen and (max-width: 480px) {
+    .footer-link {
+      display: block;
+    }
+  }
   .footer-link li {
     margin: 0 2rem;
     padding-bottom: 1rem;

--- a/src/utils/highlightMarkdown.ts
+++ b/src/utils/highlightMarkdown.ts
@@ -23,5 +23,10 @@ export function highlightMarkdown(html: string) {
     $(elm).attr('style', 'max-width: 80vw;');
   });
 
+  $('h2').each((_, elm) => {
+    $(elm).html();
+    $(elm).attr('style', 'margin-top: 1.5em; border-bottom: 2px solid #666; display: inline-block; padding: 0 6px 6px 6px;');
+  });
+
   return $.html();
 }

--- a/src/utils/highlightMarkdown.ts
+++ b/src/utils/highlightMarkdown.ts
@@ -25,8 +25,10 @@ export function highlightMarkdown(html: string) {
 
   $('h2').each((_, elm) => {
     $(elm).html();
-    $(elm).attr('style', 'margin-top: 1.5em; border-bottom: 2px solid #666; display: inline-block; padding: 0 6px 6px 6px;');
+    $(elm).attr('style', 'margin-top: 1em; border-bottom: 2px solid #666; display: inline-block; padding: 0 6px 6px 6px;');
   });
+
+  $('body').attr('style', 'line-height: 1.9; letter-spacing: 0.06em;');
 
   return $.html();
 }

--- a/src/utils/highlightMarkdown.ts
+++ b/src/utils/highlightMarkdown.ts
@@ -18,16 +18,19 @@ export function highlightMarkdown(html: string) {
     $(elm).addClass('hljs');
   });
 
+  // 画像のwidthが固定で、SP表示で記事本文のstyleが崩れたので、max-widthを設定
   $('img').each((_, elm) => {
     $(elm).html();
     $(elm).attr('style', 'max-width: 80vw;');
   });
 
+  // githubのh2っぽく下線を引く。また、section間の余白を少し広げる。
   $('h2').each((_, elm) => {
     $(elm).html();
     $(elm).attr('style', 'margin-top: 1em; border-bottom: 2px solid #666; display: inline-block; padding: 0 6px 6px 6px;');
   });
 
+  // 字が詰まって読みにくいので、その対応
   $('body').attr('style', 'line-height: 1.9; letter-spacing: 0.06em;');
 
   return $.html();

--- a/src/utils/highlightMarkdown.ts
+++ b/src/utils/highlightMarkdown.ts
@@ -18,5 +18,10 @@ export function highlightMarkdown(html: string) {
     $(elm).addClass('hljs');
   });
 
+  $('img').each((_, elm) => {
+    $(elm).html();
+    $(elm).attr('style', 'max-width: 80vw;');
+  });
+
   return $.html();
 }


### PR DESCRIPTION
- https://github.com/yuseipen0716/yusei_note/issues/19
- https://github.com/yuseipen0716/yusei_note/issues/20
- https://github.com/yuseipen0716/yusei_note/issues/21

の対応

markdown形式で書かれたtextをhtmlにparseしているだけなので、imgタグやh2タグなどに適切にstyleが当たっておらず、SP表示した際にデザイン崩れを起こしていたため修正。

Footer部分もSP対応