### PR TITLE
ブログ入稿環境をリッチエディタのβ版に変えてみる

### DIFF
--- a/src/pages/articles/[blogId].astro
+++ b/src/pages/articles/[blogId].astro
@@ -8,6 +8,7 @@ import { highlightMarkdown } from "../../utils/highlightMarkdown";
 import { marked } from "marked";
 // codeのsyntax highlightのthemeを変えたいときは以下を変更(demo: https://highlightjs.org/static/demo/)
 import 'highlight.js/styles/vs2015.css'
+import '../../styles/blog_page_style.css'
 
 // 詳細記事ページの全パスを取得
 export async function getStaticPaths() {
@@ -23,9 +24,8 @@ export async function getStaticPaths() {
 const { blogId } = Astro.params;
 const blog = await getBlogDetail(blogId as string);
 
-// microCMSから返されたプレーンテキストをmarkdownにparse
-const parsed = marked.parse(blog.content, { gfm: true })
-const html = highlightMarkdown(parsed)
+// microCMSのblogAPIから取得した記事本文にhighlightを当てる
+const html = highlightMarkdown(blog.content)
 
 const categories = blog.category
 ---

--- a/src/styles/blog_page_style.css
+++ b/src/styles/blog_page_style.css
@@ -24,3 +24,13 @@ figure {
     height: auto;
   }
 }
+
+.filename-label {
+  margin-top: 2em;
+  font-weight: bold;
+  font-size: 14px;
+  background-color: #F8F8F8;
+  padding: 4px 8px;
+  border-bottom: 1px solid #E7E7E7;
+  display: block;
+}

--- a/src/styles/blog_page_style.css
+++ b/src/styles/blog_page_style.css
@@ -1,0 +1,26 @@
+body {
+  line-height: 1.9;
+  letter-spacing: 0.06em;
+}
+
+h1 {
+  line-height: 1.2;
+}
+
+h2 {
+  margin-top: 1em;
+  padding: 0 6px 6px 6px;
+  border-bottom: 2px solid #bbb;
+  display: inline-block;
+}
+
+figure {
+  margin: 1.5em 0;
+}
+
+@media screen and (max-width: 480px) {
+  figure img {
+    max-width: 100%;
+    height: auto;
+  }
+}

--- a/src/utils/highlightMarkdown.ts
+++ b/src/utils/highlightMarkdown.ts
@@ -18,20 +18,5 @@ export function highlightMarkdown(html: string) {
     $(elm).addClass('hljs');
   });
 
-  // 画像のwidthが固定で、SP表示で記事本文のstyleが崩れたので、max-widthを設定
-  $('img').each((_, elm) => {
-    $(elm).html();
-    $(elm).attr('style', 'max-width: 80vw;');
-  });
-
-  // githubのh2っぽく下線を引く。また、section間の余白を少し広げる。
-  $('h2').each((_, elm) => {
-    $(elm).html();
-    $(elm).attr('style', 'margin-top: 1em; border-bottom: 2px solid #bbb; display: inline-block; padding: 0 6px 6px 6px;');
-  });
-
-  // 字が詰まって読みにくいので、その対応
-  $('body').attr('style', 'line-height: 1.9; letter-spacing: 0.06em;');
-
   return $.html();
 }

--- a/src/utils/highlightMarkdown.ts
+++ b/src/utils/highlightMarkdown.ts
@@ -18,5 +18,12 @@ export function highlightMarkdown(html: string) {
     $(elm).addClass('hljs');
   });
 
+  // data-filename属性を持つdivタグにファイル名表示用の要素を追加
+  $('div[data-filename]').each(function () {
+    const filename = $(this).data('filename') as unknown as string;
+    const filenameElement = $('<div>').addClass('filename-label').text(filename);
+    $(this).prepend(filenameElement);
+  });
+
   return $.html();
 }


### PR DESCRIPTION
リッチエディタのベータ版が出たらしいのでブログの入稿環境を変えてみる。

APIスキーマ変更に伴い、ブログの記事は吹き飛ぶので移管が必要

markdownをパーすしていた部分は削除したが、当然スタイルも崩れたので修正

コードブロックのところにファイル名を設定できるようになったらしいので、QiitaとかZennみたいにコードブロックの上部にファイル名を表示するようにした

![image](https://user-images.githubusercontent.com/81737622/235835881-e03ef441-533d-4ce8-a1a0-393d1e68498d.png)
